### PR TITLE
fix(date-time-picker): force selected day to always be rounded

### DIFF
--- a/react/components/Form/DateTimePicker/react-datepicker.global.css
+++ b/react/components/Form/DateTimePicker/react-datepicker.global.css
@@ -381,6 +381,7 @@
   color: #ccc;
   display: inline-block;
   width: 1.7rem;
+  height: 1.7rem;
   line-height: 1.7rem;
   text-align: center;
   margin: 0.166rem;
@@ -406,6 +407,7 @@
   color: #000;
   display: inline-block;
   width: 1.7rem;
+  height: 1.7rem;
   line-height: 1.7rem;
   text-align: center;
   margin: 0.166rem;


### PR DESCRIPTION
The UI gets a little weird sometimes. This fix makes sure that the selected day will always be rounded.

<img width="1125" alt="Screen Shot 2019-03-26 at 19 09 58" src="https://user-images.githubusercontent.com/7659279/55036908-cceccc80-4ffa-11e9-8016-1b90e40275fc.png">
