### PR TITLE
[POC] New component: InputLabel

### DIFF
--- a/react/InputLabel.js
+++ b/react/InputLabel.js
@@ -1,0 +1,3 @@
+import InputLabel from './components/Form/InputLabel/index'
+
+export default InputLabel

--- a/react/components/Form/CurrencyInput/index.js
+++ b/react/components/Form/CurrencyInput/index.js
@@ -4,6 +4,8 @@ import InputMask from 'react-input-mask'
 
 import styles from './style.css'
 
+import InputLabel from '../InputLabel/index'
+
 class CurrencyInput extends PureComponent {
   _baseDivider
 
@@ -115,6 +117,7 @@ class CurrencyInput extends PureComponent {
       id,
       label,
       withoutStyle,
+      required,
     } = this.props
     const { value } = this.state
 
@@ -147,55 +150,71 @@ class CurrencyInput extends PureComponent {
       autoComplete: 'off',
     }
 
+    const LabelComponent = (
+      <InputLabel
+        text={label}
+        required={required}
+        hasError={hasError}
+        htmlFor={inputId}
+      />
+    )
+
     if (this.props.mask) {
       return (
-        <InputMask
-          {...props}
-          className={inputClasses}
-          mask={mask}
-          maskChar={maskChar}
-          alwaysShowMask={alwaysShowMask}
-        />
+        <React.Fragment>
+          {LabelComponent}
+          <InputMask
+            {...props}
+            className={inputClasses}
+            mask={mask}
+            maskChar={maskChar}
+            alwaysShowMask={alwaysShowMask}
+          />
+        </React.Fragment>
       )
     }
     if (this.props.suffix) {
       return (
-        <div className={`dib ${className}`}>
-          <div className="flex">
-            <input {...props} className={`${inputClasses} w-100 dib ba br-0 br1 br--left`} />
-            <span className={`ba br2 br--right b--base-4 inline-flex items-center g-ph3 c-on-base-2`}>
-              {this.props.suffix}
-            </span>
+        <React.Fragment>
+          {LabelComponent}
+          <div className={`dib ${className}`}>
+            <div className="flex">
+              <input {...props} className={`${inputClasses} w-100 dib ba br-0 br1 br--left`} />
+              <span className={`ba br2 br--right b--base-4 inline-flex items-center g-ph3 c-on-base-2`}>
+                {this.props.suffix}
+              </span>
+            </div>
           </div>
-        </div>
+        </React.Fragment>
       )
     }
     if (this.props.iconBefore) {
       return (
-        <div className={`dib ${style} ${colors} ${className} overflow-hidden`}>
-          <div className="flex flex-auto items-center ">
-            <div className="g-pl3">{this.props.iconBefore}</div>
-            <input {...props} className={`${colors} ${padding} ${style} bn w-100 dib`} />
-          </div>
-        </div>
-      )
-    } else {
-      return (
         <React.Fragment>
-          {label && <label className="db c-on-base-2 g-mb1 g-f2 lh-copy" htmlFor={inputId}>{label}</label>}
-          <input {...props} className={inputClasses} />
-          {showMaxLength && maxLength !== 0 && (
-            <label
-              className={`flex flex-row-reverse db g-pb2 g-pa1 g-f2 ${
-                maxLength - this.state.value.length <= 0 ? 'red' : 'c-on-base-2'
-              }`}
-            >
-              {maxLength && maxLength - this.state.value.length}
-            </label>
-          )}
+          {LabelComponent}
+          <div className={`dib ${style} ${colors} ${className} overflow-hidden`}>
+            <div className="flex flex-auto items-center ">
+              <div className="g-pl3">{this.props.iconBefore}</div>
+              <input {...props} className={`${colors} ${padding} ${style} bn w-100 dib`} />
+            </div>
+          </div>
         </React.Fragment>
       )
     }
+
+    return (
+      <React.Fragment>
+        {LabelComponent}
+        <input {...props} className={inputClasses} />
+        {showMaxLength && maxLength !== 0 && (
+          <InputLabel
+            text={`${maxLength && maxLength - this.state.value.length}`}
+            className="flex flex-row-reverse db g-pb2 g-pa1 g-f2"
+            hasError={maxLength - this.state.value.length <= 0}
+          />
+        )}
+      </React.Fragment>
+    )
   }
 }
 
@@ -214,6 +233,8 @@ CurrencyInput.propTypes = {
   defaultValue: PropTypes.any,
   /** Add placeholder text. */
   placeholder: PropTypes.string,
+  /** Make it obligatory */
+  required: PropTypes.bool,
   /** Visually change input to present error. */
   hasError: PropTypes.bool,
   /** Make input disabled. */
@@ -273,6 +294,7 @@ CurrencyInput.defaultProps = {
   currencyIsInteger: false,
   value: '',
   placeholder: '',
+  required: false,
   formatPlaceholder: false,
   hasError: false,
   disabled: false,

--- a/react/components/Form/DateTimePicker/index.js
+++ b/react/components/Form/DateTimePicker/index.js
@@ -4,8 +4,9 @@ import DatePicker, { registerLocale } from 'react-datepicker'
 
 import './react-datepicker.global.css'
 import styles from './style.css'
-
 import * as locales from './locales'
+
+import InputLabel from '../InputLabel/index'
 
 class DateTimePicker extends PureComponent {
   componentDidMount() {
@@ -60,6 +61,7 @@ class DateTimePicker extends PureComponent {
       options,
       withoutStyle,
       defaultValue,
+      required,
     } = this.props
 
     const padding = 'g-ph4 f6 '
@@ -88,33 +90,46 @@ class DateTimePicker extends PureComponent {
       ...options,
     }
 
+    const LabelComponent = (
+      <InputLabel
+        text={label}
+        required={required}
+        hasError={hasError}
+        htmlFor={inputId}
+      />
+    )
+
     if (this.props.suffix) {
       return (
-        <div className={`dib datepicker_gocommerce ${className} ${containerClassName}`}>
-          <div className="flex">
-            <DatePicker {...props} className={`${DateTimePickerClasses} w-100 dib ba br-0 br1 br--left`} />
-            <span className="ba br2 br--right b--base-4 inline-flex items-center g-ph3 c-on-base-2">
-              {this.props.suffix}
-            </span>
+        <React.Fragment>
+          {LabelComponent}
+          <div className={`dib datepicker_gocommerce ${className} ${containerClassName}`}>
+            <div className="flex">
+              <DatePicker {...props} className={`${DateTimePickerClasses} w-100 dib ba br-0 br1 br--left`} />
+              <span className="ba br2 br--right b--base-4 inline-flex items-center g-ph3 c-on-base-2">
+                {this.props.suffix}
+              </span>
+            </div>
           </div>
-        </div>
+        </React.Fragment>
       )
     }
     if (this.props.iconBefore) {
       return (
-        <div
-          className={`dib datepicker_gocommerce ${style} ${colors} ${className} overflow-hidden ${containerClassName}`}
-        >
-          <div className="flex flex-auto items-center ">
-            <div className="g-pl3">{this.props.iconBefore}</div>
-            <DatePicker {...props} className={`${colors} ${padding} ${style} bn w-100 dib`} />
+        <React.Fragment>
+          {LabelComponent}
+          <div className={`dib datepicker_gocommerce ${style} ${colors} ${className} overflow-hidden ${containerClassName}`}>
+            <div className="flex flex-auto items-center ">
+              <div className="g-pl3">{this.props.iconBefore}</div>
+              <DatePicker {...props} className={`${colors} ${padding} ${style} bn w-100 dib`} />
+            </div>
           </div>
-        </div>
+        </React.Fragment>
       )
     }
     return (
       <div className={`dib datepicker_gocommerce ${containerClassName}`}>
-        {label && <label className="db c-on-base-2 g-mb1 g-f2 lh-copy" htmlFor={inputId}>{label}</label>}
+        {LabelComponent}
         <DatePicker {...props} className={DateTimePickerClasses} />
       </div>
     )
@@ -134,6 +149,8 @@ DateTimePicker.propTypes = {
   defaultValue: PropTypes.any,
   /** Add placeholder text. */
   placeholder: PropTypes.string,
+  /** Make it obligatory */
+  required: PropTypes.bool,
   /** Visually change DateTimePicker to present error. */
   hasError: PropTypes.bool,
   /** Make DateTimePicker disabled. */
@@ -171,6 +188,7 @@ DateTimePicker.defaultProps = {
   showMaxLength: false,
   suffix: null,
   iconBefore: null,
+  required: false,
 }
 
 export default DateTimePicker

--- a/react/components/Form/Input/index.js
+++ b/react/components/Form/Input/index.js
@@ -184,6 +184,8 @@ Input.propTypes = {
   defaultValue: PropTypes.any,
   /** Add placeholder text. */
   placeholder: PropTypes.string,
+  /** Make it obligatory */
+  required: PropTypes.bool,
   /** Visually change input to present error. */
   hasError: PropTypes.bool,
   /** Make input disabled. */
@@ -245,6 +247,7 @@ Input.defaultProps = {
   alwaysShowMask: false,
   suffix: null,
   iconBefore: null,
+  required: false,
 }
 
 export default Input

--- a/react/components/Form/Input/index.js
+++ b/react/components/Form/Input/index.js
@@ -1,7 +1,10 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import InputMask from 'react-input-mask'
+
 import styles from './style.css'
+
+import InputLabel from '../InputLabel/index'
 
 class Input extends PureComponent {
   constructor(props) {
@@ -97,10 +100,19 @@ class Input extends PureComponent {
       autoComplete: 'off',
     }
 
+    const LabelComponent = (
+      <InputLabel
+        text={label}
+        required={required}
+        hasError={hasError}
+        htmlFor={inputId}
+      />
+    )
+
     if (this.props.mask) {
       return (
         <React.Fragment>
-          {label && <label className="db c-on-base-2 g-mb1 g-f2 lh-copy" htmlFor={inputId}>{label}</label>}
+          {LabelComponent}
           <InputMask
             {...props}
             className={inputClasses}
@@ -113,47 +125,44 @@ class Input extends PureComponent {
     }
     if (this.props.suffix) {
       return (
-        <div className={`dib ${className}`}>
-          <div className="flex">
-            <input {...props} className={`${inputClasses} w-100 dib ba br-0 br1 br--left`} />
-            <span
-              className={`ba br2 br--right inline-flex items-center g-ph3 ${!hasError ? 'c-on-base-2' : ''} ${colors}`}
-            >
-              {this.props.suffix}
-            </span>
+        <React.Fragment>
+          {LabelComponent}
+          <div className={`dib ${className}`}>
+            <div className="flex">
+              <input {...props} className={`${inputClasses} w-100 dib ba br-0 br1 br--left`} />
+              <span
+                className={`ba br2 br--right inline-flex items-center g-ph3 ${!hasError ? 'c-on-base-2' : ''} ${colors}`}
+              >
+                {this.props.suffix}
+              </span>
+            </div>
           </div>
-        </div>
+        </React.Fragment>
       )
     }
     if (this.props.iconBefore) {
       return (
-        <div className={`dib ${style} ${colors} ${className} overflow-hidden`}>
-          <div className="flex flex-auto items-center ">
-            <div className="g-pl3">{this.props.iconBefore}</div>
-            <input {...props} className={`${colors} ${padding} ${style} bn w-100 dib`} />
+        <React.Fragment>
+          {LabelComponent}
+          <div className={`dib ${style} ${colors} ${className} overflow-hidden`}>
+            <div className="flex flex-auto items-center ">
+              <div className="g-pl3">{this.props.iconBefore}</div>
+              <input {...props} className={`${colors} ${padding} ${style} bn w-100 dib`} />
+            </div>
           </div>
-        </div>
+        </React.Fragment>
       )
     }
     return (
       <React.Fragment>
-        {label && (
-          <label
-            className="db c-on-base-2 g-mb1 g-f2 lh-copy"
-            htmlFor={inputId}
-          >
-            {`${label}${required ? '*' : ''}`}
-          </label>
-        )}
+        {LabelComponent}
         <input {...props} className={inputClasses} />
         {showMaxLength && maxLength !== 0 && (
-          <label
-            className={`flex flex-row-reverse db g-pb2 g-pa1 g-f2 ${
-              maxLength - this.state.value.length <= 0 ? 'red' : 'c-on-base-2'
-            }`}
-          >
-            {maxLength && maxLength - this.state.value.length}
-          </label>
+          <InputLabel
+            text={`${maxLength && maxLength - this.state.value.length}`}
+            className="flex flex-row-reverse db g-pb2 g-pa1 g-f2"
+            hasError={maxLength - this.state.value.length <= 0}
+          />
         )}
       </React.Fragment>
     )

--- a/react/components/Form/InputLabel/README.md
+++ b/react/components/Form/InputLabel/README.md
@@ -1,0 +1,20 @@
+#### Accepted props:
+
+| prop name | type    | default | required |
+|-----------|---------|---------|----------|
+| text      | string  |         | No       |
+| htmlFor   | string  |         | No       |
+| hasError  | boolean | false   | No       |
+| required  | boolean | false   | No       |
+| className | string  |         | No       |
+
+#### Usage
+
+```js
+<InputLabel
+  text="Name"
+  htmlFor="name"
+  hasError={false}
+  required={true}
+/>
+```

--- a/react/components/Form/InputLabel/index.js
+++ b/react/components/Form/InputLabel/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const InputLabel = ({ htmlFor, required, text, hasError, className }) => {
+  if (!text) return null
+  return (
+    <label
+      className={`db g-mb1 g-f2 lh-copy ${hasError ? 'c-danger' : 'c-on-base-2'} ${className}`}
+      htmlFor={htmlFor}
+    >
+      {`${text}${required ? '*' : ''}`}
+    </label>
+  )
+}
+
+export default InputLabel

--- a/react/components/Form/InputTag/index.js
+++ b/react/components/Form/InputTag/index.js
@@ -245,7 +245,7 @@ InputTag.propTypes = {
   onChange: PropTypes.func,
   autocomplete: PropTypes.bool,
   source: PropTypes.array,
-  required: PropTypes.boolean,
+  required: PropTypes.bool,
 }
 
 InputTag.defaultProps = {
@@ -263,6 +263,7 @@ InputTag.defaultProps = {
   onChangeInput: () => {},
   source: [],
   input: '',
+  required: false,
 }
 
 export default InputTag


### PR DESCRIPTION
Adding a new component to styleguide to unify how we handle input labels. It makes easier to add new behaviours to inputs and export an input label component in case we need (and sometimes we do) to use labels unattached from an input.

The label now shares the status of the input, what I think is great.
![Kapture 2019-10-18 at 10 20 10](https://user-images.githubusercontent.com/7659279/67097857-63e4c600-f191-11e9-8b7f-ab8f6f11b404.gif)
 