### PR TITLE
Fix placeholder not filling full width

### DIFF
--- a/react/components/Form/InputTag/index.js
+++ b/react/components/Form/InputTag/index.js
@@ -151,14 +151,14 @@ class InputTag extends Component {
 
   getTagList = () => {
     return (
-      <div className="flex items-center">
+      <div className="flex items-center flex-auto">
         {!!this.props.iconBefore && (
           <div className="g-pa4 c-on-base-2 flex">
             {this.props.iconBefore}
           </div>
         )}
 
-        <div className="flex flex-wrap">
+        <div className="flex flex-wrap flex-auto">
           {this.props.fixedTags.map((data, index) => (
             <span key={`${data}#${index}`} className="inline-flex g-ml1 g-mb1 g-mt1 o-50">
               <Tag style={this.props.tagStyle}>


### PR DESCRIPTION
Problem:
Text getting cut on promotions edit form.
![without-flex](https://user-images.githubusercontent.com/27388955/71033031-58f8d400-20f5-11ea-8dca-240c05d59e4a.png)

Fix:
Add "flex-auto" to `InputTag` inner components, so the text occupies the full possible width.
![with-flex](https://user-images.githubusercontent.com/27388955/71033036-5b5b2e00-20f5-11ea-8f09-fd009f3332db.png)

Link to test:
https://gabrieladev--gc-wmr3721.mygocommerce.com/admin/marketing/promotions/edit/126a6851-1b4a-45e3-9e59-88fecef9d88c/