### PR TITLE
Feature/language abbreviations

### DIFF
--- a/react/components/Buttons/LanguageButton/index.js
+++ b/react/components/Buttons/LanguageButton/index.js
@@ -38,28 +38,28 @@ class LanguageButton extends PureComponent {
       <BooleanValue defaultValue={false}>
         {({ value, toggle }) => (
           <div className={`w-100 relative`}>
-            <div className={`flex items-center pointer g-f2 fw6 c-on-base-2 ${className}`} onClick={toggle}>
-              <IconEarth className="g-mr3" />
-              <span className="g-mr3">{abbreviationOn ? localeSelected.shortText : localeSelected.text}</span>
+            <div className={`flex flex-auto pointer g-f2 fw6 c-on-base-2 ${className}`} onClick={toggle}>
+              <IconEarth className="flex flex-start" />
+              <span className="flex flex-auto mh3">{abbreviationOn ? localeSelected.shortText : localeSelected.text}</span>
               {value ? (
-                <IconSortUp width="16" height="16" className="ml-auto" />
+                <IconSortUp width="16" height="16" className="flex flex-end" />
               ) : (
-                <IconSortDown width="16" height="16" className="ml-auto" />
-              )}
+                  <IconSortDown width="16" height="16" className="flex flex-end" />
+                )}
             </div>
             {value && (
-              <div className={`w-100 g-pt1`}>
+              <div className={`w-100 g-pv1`}>
                 {locales.map(({ id, text, shortText }) =>
                   id !== localeSelected.id ? (
                     <div
                       key={id}
                       id={`appframe-locale@${id}`}
-                      className={`flex items-center g-pv1 g-f2 c-on-base-2 pointer ${itemClassName}`}
+                      className={`g-ph4 g-pv1 g-f2 c-on-base-2 pointer ${itemClassName} ${abbreviationOn ? 'tc' : 'ml6'}`}
                       onClick={() => {
                         this.handleClick(id), toggle()
                       }}
                     >
-                      <span className="g-pl7">{abbreviationOn ? shortText : text}</span>
+                      <span>{abbreviationOn ? shortText : text}</span>
                     </div>
                   ) : null
                 )}
@@ -89,7 +89,7 @@ LanguageButton.propTypes = {
 LanguageButton.defaultProps = {
   className: '',
   itemClassName: '',
-  onClick: () => {},
+  onClick: () => { },
   localeSelected: '',
   locales: [],
   abbreviationOn: false

--- a/react/components/Buttons/LanguageButton/index.js
+++ b/react/components/Buttons/LanguageButton/index.js
@@ -10,6 +10,7 @@ class LanguageButton extends PureComponent {
     super(props)
 
     this.state = {
+
       localeSelected: this.findLocale(props.localeSelected)
     }
   }
@@ -28,8 +29,10 @@ class LanguageButton extends PureComponent {
   }
 
   render() {
-    const { locales, className, itemClassName } = this.props
+    const { locales, className, itemClassName, abbreviationOn } = this.props
     const { localeSelected } = this.state
+
+    console.log('props', this.props)
 
     return (
       <BooleanValue defaultValue={false}>
@@ -37,7 +40,7 @@ class LanguageButton extends PureComponent {
           <div className={`w-100 relative`}>
             <div className={`flex items-center pointer g-f2 fw6 c-on-base-2 ${className}`} onClick={toggle}>
               <IconEarth className="g-mr3" />
-              <span className="g-mr3">{localeSelected.text}</span>
+              <span className="g-mr3">{abbreviationOn ? localeSelected.shortText : localeSelected.text}</span>
               {value ? (
                 <IconSortUp width="16" height="16" className="ml-auto" />
               ) : (
@@ -46,7 +49,7 @@ class LanguageButton extends PureComponent {
             </div>
             {value && (
               <div className={`w-100 g-pt1`}>
-                {locales.map(({ id, text }) =>
+                {locales.map(({ id, text, shortText }) =>
                   id !== localeSelected.id ? (
                     <div
                       key={id}
@@ -56,7 +59,7 @@ class LanguageButton extends PureComponent {
                         this.handleClick(id), toggle()
                       }}
                     >
-                      <span className="g-pl7">{text}</span>
+                      <span className="g-pl7">{abbreviationOn ? shortText : text}</span>
                     </div>
                   ) : null
                 )}
@@ -79,7 +82,8 @@ LanguageButton.propTypes = {
     })
   ),
   className: PropTypes.string,
-  itemClassName: PropTypes.string
+  itemClassName: PropTypes.string,
+  abbreviationOn: PropTypes.bool
 }
 
 LanguageButton.defaultProps = {
@@ -87,7 +91,8 @@ LanguageButton.defaultProps = {
   itemClassName: '',
   onClick: () => {},
   localeSelected: '',
-  locales: []
+  locales: [],
+  abbreviationOn: false
 }
 
 export default LanguageButton

--- a/react/components/Buttons/LanguageButton/index.js
+++ b/react/components/Buttons/LanguageButton/index.js
@@ -31,9 +31,7 @@ class LanguageButton extends PureComponent {
   render() {
     const { locales, className, itemClassName, abbreviationOn } = this.props
     const { localeSelected } = this.state
-
-    console.log('props', this.props)
-
+    
     return (
       <BooleanValue defaultValue={false}>
         {({ value, toggle }) => (


### PR DESCRIPTION
Add `abbreviationOn` property option for `Language Button`. When property is set to `true` languages are displayed like `PT`, `EN`, `ES`.

Link for testing:
https://gabrieladev--gc-wmr3721.mygocommerce.com/admin/dashboard