### PR TITLE
Make tooltip smarter

### DIFF
--- a/react/components/Indicators/Tooltip/index.js
+++ b/react/components/Indicators/Tooltip/index.js
@@ -3,29 +3,41 @@ import PropTypes from 'prop-types'
 import styles from './style.css'
 
 class Tooltip extends Component {
+  state = {
+    show: false
+  }
   render() {
     return (
-      <div
-        className={`gc_tooltip z-5 absolute br2 g-pa4 bg-base-inverted-1 c-white
-        ${styles.gc_tooltip} ${this.props.className} ${!this.props.show ? 'dn' : ''}`}
-        style={{ width: this.props.width }}
-      >
-        {this.props.children}
-      </div>
+      <>
+        <div className="dib mr2 relative">
+          <div
+            className={`gc_tooltip z-5 absolute br2 g-pa2 bg-base-inverted-1 g-f1 c-white tc
+            ${styles.gc_tooltip} ${this.props.className} ${this.state.show ? '' : 'dn'}`}
+            style={{ width: this.props.width }}
+          >
+            {this.props.label}
+          </div>
+          <div
+            onMouseEnter={() => this.setState({ show: true })}
+            onMouseLeave={() => this.setState({ show: false })}
+          >
+            {this.props.children}
+          </div>
+        </div>
+      </>
     )
   }
 }
 
 Tooltip.propTypes = {
-  show: PropTypes.bool,
   width: PropTypes.string,
+  label: PropTypes.string,
   children: PropTypes.node.isRequired,
   className: PropTypes.string
 }
 
 Tooltip.defaultProps = {
-  show: false,
-  width: 'auto',
+  width: '200px',
   className: ''
 }
 

--- a/react/components/Indicators/Tooltip/index.js
+++ b/react/components/Indicators/Tooltip/index.js
@@ -1,44 +1,34 @@
-import React, { Component } from 'react'
+import React, { Component, useState } from 'react'
 import PropTypes from 'prop-types'
 import styles from './style.css'
 
-class Tooltip extends Component {
-  state = {
-    show: false
-  }
-  render() {
-    return (
-      <>
-        <div className="dib mr2 relative">
-          <div
-            className={`gc_tooltip z-5 absolute br2 g-pa2 bg-base-inverted-1 g-f1 c-white tc
-            ${styles.gc_tooltip} ${this.props.className} ${this.state.show ? '' : 'dn'}`}
-            style={{ width: this.props.width }}
-          >
-            {this.props.label}
-          </div>
-          <div
-            onMouseEnter={() => this.setState({ show: true })}
-            onMouseLeave={() => this.setState({ show: false })}
-          >
-            {this.props.children}
-          </div>
-        </div>
-      </>
-    )
-  }
+const Tooltip = ({ className = '', children, text }) => {
+  const [show, setShow] = useState(false)
+
+  return (
+    <div className="dib mr2 relative">
+      <div
+        className={`gc_tooltip z-5 absolute br2 g-pa2 bg-base-inverted-1 g-f1 c-white tc
+          ${styles.gc_tooltip} ${className} ${show ? '' : 'dn'}`
+        }
+        style={{ width: '200px' }}
+      >
+        <span>{text}</span>
+      </div>
+      <div
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+      >
+        {children}
+      </div>
+    </div>
+  )
 }
 
 Tooltip.propTypes = {
-  width: PropTypes.string,
-  label: PropTypes.string,
+  text: PropTypes.string,
   children: PropTypes.node.isRequired,
   className: PropTypes.string
-}
-
-Tooltip.defaultProps = {
-  width: '200px',
-  className: ''
 }
 
 export default Tooltip

--- a/react/components/Indicators/Tooltip/index.js
+++ b/react/components/Indicators/Tooltip/index.js
@@ -7,13 +7,15 @@ const Tooltip = ({ className = '', children, text }) => {
 
   return (
     <div className="dib mr2 relative">
-      <div
-        className={`gc_tooltip z-5 absolute br2 g-pa2 bg-base-inverted-1 g-f1 c-white tc
-          ${styles.gc_tooltip} ${className} ${show ? '' : 'dn'}`
-        }
-        style={{ width: '200px' }}
-      >
-        <span>{text}</span>
+      <div className={`absolute ${styles.gc_tooltip_container}`} style={{ width: '250px' }}>
+        <div
+          className={`z-5 br2 g-pa2 bg-base-inverted-1 g-f1 c-white tc
+            ${styles.gc_tooltip} ${className} ${show ? '' : 'dn'}`
+          }
+          style={{ width: 'fit-content' }}
+        >
+          <span>{text}</span>
+        </div>
       </div>
       <div
         onMouseEnter={() => setShow(true)}

--- a/react/components/Indicators/Tooltip/index.js
+++ b/react/components/Indicators/Tooltip/index.js
@@ -6,9 +6,8 @@ class Tooltip extends Component {
   render() {
     return (
       <div
-        className={`gc_tooltip z-5 absolute br2 g-pa4 bg-base-inverted-1 c-white ${styles.gc_tooltip} ${
-          this.props.className
-        }`}
+        className={`gc_tooltip z-5 absolute br2 g-pa4 bg-base-inverted-1 c-white
+        ${styles.gc_tooltip} ${this.props.className} ${!this.props.show ? 'dn' : ''}`}
         style={{ width: this.props.width }}
       >
         {this.props.children}
@@ -24,7 +23,7 @@ Tooltip.propTypes = {
   className: PropTypes.string
 }
 
-Tooltip.Tooltip = {
+Tooltip.defaultProps = {
   show: false,
   width: 'auto',
   className: ''

--- a/react/components/Indicators/Tooltip/style.css
+++ b/react/components/Indicators/Tooltip/style.css
@@ -1,5 +1,8 @@
-.gc_tooltip {
+.gc_tooltip_container {
   bottom: 130%;
+  left: 50%;
+}
+.gc_tooltip {
   left: 50%;
   transform: translate(-50%, 0);
 }


### PR DESCRIPTION
Problems:
Prop `show` was just hanging around doing nothing. Also `defaultProps` were not being set properly.

Fixes:
Component shows/hide automatically on `mouseover`/`mouseout` events. And adjusts its width dynamically as well.