### PR TITLE
Fix currency to number funtion

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "cleanlib": "rm -rf lib",
     "entrypoints": "node ./scripts/entrypoints.js",
     "gen-icons": "node ./scripts/svgToComponent.js && npm run entrypoints",
-    "copycss": "copyfiles -u 2 react/**/*.css lib"
+    "copycss": "copyfiles -u 2 react/**/*.css lib",
+    "test:react": "jest react"
   },
   "homepage": "https://vtex-gocommerce.github.io/styleguide",
   "devDependencies": {

--- a/react/components/Form/Input/__tests__/currencyFunctions.test.js
+++ b/react/components/Form/Input/__tests__/currencyFunctions.test.js
@@ -1,0 +1,73 @@
+import Functions from '../currencyFunctions'
+
+const currencySpecBR = {
+  currencySymbol: 'R$',
+  currencyFormatInfo: {
+    currencyDecimalDigits: 2,
+    currencyGroupSize: 3,
+    currencyGroupSeparator: '.',
+    currencyDecimalSeparator: ',',
+    startsWithCurrencySymbol: true,
+  }
+}
+
+const currencySpecEUR = {
+  currencySymbol: '€',
+  currencyFormatInfo: {
+    currencyDecimalDigits: 2,
+    currencyDecimalSeparator: ",",
+    currencyGroupSeparator: ".",
+    currencyGroupSize: 3,
+    startsWithCurrencySymbol: false,
+  }
+}
+
+describe('Test currency functions', () => {
+  test('currency to number as integer', () => {
+    const value = 'R$ 4,10'
+    const baseDivider = 100
+    const props = {
+      currencyIsInteger: true,
+      currencySpec: currencySpecBR,
+    }
+
+    const formattedNumber = Functions.currencyToNumber(value, props, baseDivider)
+    expect(formattedNumber).toEqual(410)
+  })
+
+  test('remove currency symbol', () => {
+    const real = Functions.removeCurrencySymbols('R$ 42,00')
+    const dolar = Functions.removeCurrencySymbols('USD 42.00')
+    const pesoCL = Functions.removeCurrencySymbols('4200 CLP')
+
+    expect(real).toEqual('42,00')
+    expect(dolar).toEqual('42.00')
+    expect(pesoCL).toEqual('4200')
+  })
+
+  test('format number to currency BR', () => {
+    const value = '42.00'
+    const props = {
+      showCurrency: true,
+      currencySpec: currencySpecBR,
+    }
+    const baseDivider = 100
+
+    const formattedValue = Functions.toCurrency(value, props, baseDivider)
+
+    expect(formattedValue).toEqual('R$ 42,00')
+  })
+
+  test('format number to currency EUR', () => {
+    const value = '42.00'
+    const props = {
+      showCurrency: true,
+      currencySpec: currencySpecEUR,
+    }
+    const baseDivider = 100
+
+    const formattedValue = Functions.toCurrency(value, props, baseDivider)
+
+    expect(formattedValue).toEqual('42,00 €')
+  })
+})

--- a/react/components/Form/Input/currencyFunctions.js
+++ b/react/components/Form/Input/currencyFunctions.js
@@ -54,7 +54,9 @@ const CurrencyFunctions = {
     let number = CurrencyFunctions.removeCurrencySymbols(value)
     number = number.replace(separatorRegex, '').replace(currencyDecimalSeparator, '.')
 
-    return props.currencyIsInteger ? parseInt(number * _baseDivider) : number
+    return props.currencyIsInteger
+      ? Math.round(parseFloat(number) * _baseDivider)
+      : number
   },
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix how we transform a currency value to a number.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
Related to https://app.clubhouse.io/vtex/story/33954/comportamento-estranho-ao-digitar-alguns-valores-de-desconto

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://augusto--bolinhodearroz.mygocommerce.com/admin/marketing/promotions/edit/93a0371a-3bd5-4c4c-a4a7-8b05064ea5b5/
There are some unit tests as well, just run `yarn test:react` at the project root folder.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
